### PR TITLE
CI: Fix CircleCI workflows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,9 @@ workflows:
     jobs:
     - codespell:
         filters:
+          branches:
+            only:
+              - main
           tags:
             only: /.*/
     - build:
@@ -61,4 +64,6 @@ workflows:
           branches:
             only:
               - main
+          tags:
+            only:
               - /v[0-9]+(\.[0-9]+)*(-.*)*/


### PR DESCRIPTION
This PR fix CircleCI, which was not running:
- codespell on main branch
- build on tags