### PR TITLE
fabric_links: Add new collector for consuming /fabric/v1/links API metrics

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,7 +8,7 @@ linters-settings:
   gocyclo:
     min-complexity: 40
   dupl:
-    threshold: 150
+    threshold: 200
   misspell:
     locale: US
   lll:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## v0.0.4 / unreleased
+
+* Add "/fabric/v1/links" collector
+* chore: Refactor exporter for consuming another API.
+
 ## v0.0.3 / 2023-09-11
 
 * Update ziti from v0.29 to v0.30.3

--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ A helm chart called `prometheus-openziti-exporter` is available at [enthus-it](h
 ### OpenZiti Management Edge API configuration
 
 This exporter consumes the [OpenZiti Management Edge API](https://openziti.io/docs/reference/developer/api/edge-management-reference),
-and needs to be configured accordingly.
+the [OpenZiti Fabric API](https://openziti.io/docs/reference/developer/api/fabric-api), and needs to be configured accordingly.
 
 Flag / Environment Variable         |  Description |
 ------------------------------------|--------------|
-`--ziti.mgt.api` / `ZITI_MGMT_API`  | OpenZiti Edge Management API URL. |
-`--ziti.admin.username` / `ZITI_ADMIN_USER`  | OpenZiti Edge Management API Admin Username. |
-`--ziti.admin.password` / `ZITI_ADMIN_PASSWORD`  | OpenZiti Edge Management API Admin Password. |
+`--ziti.mgt.api` / `ZITI_MGMT_API`  | OpenZiti  API basepath URL. |
+`--ziti.admin.username` / `ZITI_ADMIN_USER`  | OpenZiti Admin Username. |
+`--ziti.admin.password` / `ZITI_ADMIN_PASSWORD`  | OpenZiti API Admin Password. |
 
 **NOTE**: If the User is not an Administrator, then no information will be returned by the API.
 
@@ -48,6 +48,7 @@ To enable only some specific collector(s), use `--collector.disable-defaults --c
 
 Name     | Description |
 ---------|-------------|
+fabric_links | Exposes OpenZiti Fabric Links from the Fabric API. |
 identities | Exposes OpenZiti Identities from the Edge Management API. |
 routers | Exposes OpenZiti Edge-Routers from the Edge Management API. |
 

--- a/collector/collector_struct.go
+++ b/collector/collector_struct.go
@@ -21,20 +21,21 @@ import (
 // LoginOptions are the flags for login commands
 type LoginOptions struct {
 	api.Options
-	Username        string
-	Password        string
-	Host            string
-	HostReady       string
-	Token           string
-	Logger          log.Logger
-	CaCert          string
-	ReadOnly        bool
-	Yes             bool
-	IgnoreConfig    bool
-	ClientCert      string
-	ClientKey       string
-	ExtJwt          string
-	IdentTypeFilter []string
+	Username                   string
+	Password                   string
+	Host                       string
+	HostReadyEdgeManagementAPI string
+	HostReadyFabricAPI         string
+	Token                      string
+	Logger                     log.Logger
+	CaCert                     string
+	ReadOnly                   bool
+	Yes                        bool
+	IgnoreConfig               bool
+	ClientCert                 string
+	ClientKey                  string
+	ExtJwt                     string
+	IdentTypeFilter            []string
 }
 
 type LoginSession struct {

--- a/collector/fabric_links_collector.go
+++ b/collector/fabric_links_collector.go
@@ -1,0 +1,174 @@
+// Copyright 2023 enthus GmbH
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	jsoniter "github.com/json-iterator/go"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	nano2seconds     = 1e9
+	fabricLinksSpace = "fabric_links"
+)
+
+type fabricLinksCollector struct {
+	logger  log.Logger
+	options *LoginOptions
+}
+
+func init() {
+	registerCollector("fabric_links", defaultEnabled, newFabricLinksCollector)
+}
+
+// newFabricLinksCollector returns a new Collector exposing OpenZiti fabric links metrics.
+func newFabricLinksCollector(logger log.Logger, options *LoginOptions) (Collector, error) {
+	return &fabricLinksCollector{
+		logger:  logger,
+		options: options,
+	}, nil
+}
+
+// Update pushes fabric links metrics onto ch
+func (c *fabricLinksCollector) Update(ch chan<- prometheus.Metric) (err error) {
+	// if not already logged, do the login.
+	if c.options == nil {
+		c.options, err = edgeAPILogin(c.logger)
+		if err != nil {
+			return err
+		}
+	} else if c.options.Token == "" {
+		c.options, err = edgeAPILogin(c.logger)
+		if err != nil {
+			return err
+		}
+	}
+
+	fabricLinks, err := c.options.RunFabricLinks()
+	if err != nil {
+		return err
+	}
+
+	for i := range fabricLinks.Data {
+		ch <- prometheus.MustNewConstMetric(
+			prometheus.NewDesc(
+				prometheus.BuildFQName(namespace,
+					fabricLinksSpace, "status"),
+				"Fabric Link status. (1: up, 0: down)",
+				[]string{"destination", "source", "id"}, nil,
+			), prometheus.GaugeValue,
+			convertBool2Float(!fabricLinks.Data[i].Down),
+			fabricLinks.Data[i].DestRouter.Name,
+			fabricLinks.Data[i].SourceRouter.Name,
+			fabricLinks.Data[i].ID,
+		)
+		ch <- prometheus.MustNewConstMetric(
+			prometheus.NewDesc(
+				prometheus.BuildFQName(namespace,
+					fabricLinksSpace, "source_latency_seconds"),
+				"Fabric Link source latency.",
+				[]string{"destination", "source", "id"}, nil,
+			), prometheus.GaugeValue,
+			fabricLinks.Data[i].SourceLatency/nano2seconds,
+			fabricLinks.Data[i].DestRouter.Name,
+			fabricLinks.Data[i].SourceRouter.Name,
+			fabricLinks.Data[i].ID,
+		)
+		ch <- prometheus.MustNewConstMetric(
+			prometheus.NewDesc(
+				prometheus.BuildFQName(namespace,
+					fabricLinksSpace,
+					"destination_latency_seconds"),
+				"Fabric Link destination latency.",
+				[]string{"destination", "source", "id"}, nil,
+			), prometheus.GaugeValue,
+			fabricLinks.Data[i].DestLatency/nano2seconds,
+			fabricLinks.Data[i].DestRouter.Name,
+			fabricLinks.Data[i].SourceRouter.Name,
+			fabricLinks.Data[i].ID,
+		)
+		ch <- prometheus.MustNewConstMetric(
+			prometheus.NewDesc(
+				prometheus.BuildFQName(namespace,
+					fabricLinksSpace, "routing_cost"),
+				"Fabric Link routing cost which depends of the strategy configured.",
+				[]string{"destination", "source", "id"}, nil,
+			), prometheus.GaugeValue,
+			fabricLinks.Data[i].Cost,
+			fabricLinks.Data[i].DestRouter.Name,
+			fabricLinks.Data[i].SourceRouter.Name,
+			fabricLinks.Data[i].ID,
+		)
+		ch <- prometheus.MustNewConstMetric(
+			prometheus.NewDesc(
+				prometheus.BuildFQName(namespace,
+					fabricLinksSpace, "routing_static_cost"),
+				"Fabric Link routing static cost configured.",
+				[]string{"destination", "source", "id"}, nil,
+			), prometheus.GaugeValue,
+			fabricLinks.Data[i].StaticCost,
+			fabricLinks.Data[i].DestRouter.Name,
+			fabricLinks.Data[i].SourceRouter.Name,
+			fabricLinks.Data[i].ID,
+		)
+	}
+
+	return nil
+}
+
+// RunFabricLinks implements this command
+func (o *LoginOptions) RunFabricLinks() (FabricLinks, error) {
+	var (
+		limit                                     = 50
+		offset                                    = 0
+		fabricLinksStructTotal, fabricLinksStruct FabricLinks
+		json                                      = jsoniter.ConfigCompatibleWithStandardLibrary
+	)
+
+	jsonBytes, err := controllerAPICall(o, "fabric", "/links", limit, offset)
+	if err != nil {
+		return fabricLinksStructTotal, err
+	}
+
+	err = json.Unmarshal(jsonBytes, &fabricLinksStruct)
+	if err != nil {
+		return fabricLinksStructTotal, err
+	}
+
+	fabricLinksStructTotal.Data = append(fabricLinksStructTotal.Data, fabricLinksStruct.Data...)
+
+	totalFabricLinksCount := fabricLinksStruct.Meta.Pagination.TotalCount
+	level.Debug(o.Logger).Log("msg", "Total Ziti Fabric Links found", "count", totalFabricLinksCount)
+
+	for offset+limit < totalFabricLinksCount {
+		offset += limit
+
+		jsonBytes, err := controllerAPICall(o, "fabric", "/links", limit, offset)
+		if err != nil {
+			return fabricLinksStructTotal, err
+		}
+
+		err = json.Unmarshal(jsonBytes, &fabricLinksStruct)
+		if err != nil {
+			return fabricLinksStructTotal, err
+		}
+
+		fabricLinksStructTotal.Data = append(fabricLinksStructTotal.Data, fabricLinksStruct.Data...)
+	}
+
+	return fabricLinksStructTotal, err
+}

--- a/collector/fabric_links_struct.go
+++ b/collector/fabric_links_struct.go
@@ -1,0 +1,38 @@
+// Copyright 2023 enthus GmbH
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+type FabricLinks struct {
+	Data []FabricLink `json:"data"`
+	Meta MetaData     `json:"meta"`
+}
+
+// FabricLink represent the meaningful chracteristics of a Ziti Fabric Link
+// for this exporter
+type FabricLink struct {
+	Cost        float64 `json:"cost"`
+	DestLatency float64 `json:"destLatency"`
+	DestRouter  struct {
+		Name string `json:"name"`
+	} `json:"destRouter"`
+	Down          bool    `json:"down"`
+	ID            string  `json:"id"`
+	Protocol      string  `json:"protocol"`
+	SourceLatency float64 `json:"sourceLatency"`
+	SourceRouter  struct {
+		Name string `json:"name"`
+	} `json:"sourceRouter"`
+	State      string  `json:"state"`
+	StaticCost float64 `json:"staticCost"`
+}

--- a/collector/routers_collector.go
+++ b/collector/routers_collector.go
@@ -28,6 +28,10 @@ type routersCollector struct {
 	options *LoginOptions
 }
 
+const (
+	routerSpace = "router"
+)
+
 func init() {
 	registerCollector("routers", defaultEnabled, newRoutersCollector)
 }
@@ -63,7 +67,8 @@ func (c *routersCollector) Update(ch chan<- prometheus.Metric) (err error) {
 	for i := range routers.Data {
 		ch <- prometheus.MustNewConstMetric(
 			prometheus.NewDesc(
-				prometheus.BuildFQName(namespace, "", "router_online"),
+				prometheus.BuildFQName(namespace, routerSpace,
+					"online"),
 				"Router is currently online.",
 				[]string{"hostname", "role_attributes", "version"}, nil,
 			), prometheus.GaugeValue,
@@ -74,7 +79,8 @@ func (c *routersCollector) Update(ch chan<- prometheus.Metric) (err error) {
 		)
 		ch <- prometheus.MustNewConstMetric(
 			prometheus.NewDesc(
-				prometheus.BuildFQName(namespace, "", "router_enabled"),
+				prometheus.BuildFQName(namespace, routerSpace,
+					"enabled"),
 				"Router is currently enabled.",
 				[]string{"hostname", "role_attributes", "version"}, nil,
 			), prometheus.GaugeValue,
@@ -85,7 +91,8 @@ func (c *routersCollector) Update(ch chan<- prometheus.Metric) (err error) {
 		)
 		ch <- prometheus.MustNewConstMetric(
 			prometheus.NewDesc(
-				prometheus.BuildFQName(namespace, "", "router_tunneler_enabled"),
+				prometheus.BuildFQName(namespace, routerSpace,
+					"tunneler_enabled"),
 				"Router as tunneler enabled.",
 				[]string{"hostname", "role_attributes", "version"}, nil,
 			), prometheus.GaugeValue,
@@ -96,7 +103,8 @@ func (c *routersCollector) Update(ch chan<- prometheus.Metric) (err error) {
 		)
 		ch <- prometheus.MustNewConstMetric(
 			prometheus.NewDesc(
-				prometheus.BuildFQName(namespace, "", "router_service_traversal_enabled"),
+				prometheus.BuildFQName(namespace, routerSpace,
+					"service_traversal_enabled"),
 				"Router let services traverse through.",
 				[]string{"hostname", "role_attributes", "version"}, nil,
 			), prometheus.GaugeValue,
@@ -107,7 +115,8 @@ func (c *routersCollector) Update(ch chan<- prometheus.Metric) (err error) {
 		)
 		ch <- prometheus.MustNewConstMetric(
 			prometheus.NewDesc(
-				prometheus.BuildFQName(namespace, "", "router_sync_status"),
+				prometheus.BuildFQName(namespace, routerSpace,
+					"sync_status"),
 				"Router synchronization status.",
 				[]string{"hostname", "role_attributes", "version", "sync_status"}, nil,
 			), prometheus.GaugeValue,
@@ -131,7 +140,7 @@ func (o *LoginOptions) RunRouters() (Routers, error) {
 		json                            = jsoniter.ConfigCompatibleWithStandardLibrary
 	)
 
-	jsonBytes, err := edgeControllerAPICall(o, "/edge-routers", limit, offset)
+	jsonBytes, err := controllerAPICall(o, "edge_management", "/edge-routers", limit, offset)
 	if err != nil {
 		return routerStructTotal, err
 	}
@@ -149,7 +158,7 @@ func (o *LoginOptions) RunRouters() (Routers, error) {
 	for offset+limit < totalRouterCount {
 		offset += limit
 
-		jsonBytes, err := edgeControllerAPICall(o, "/edge-routers", limit, offset)
+		jsonBytes, err := controllerAPICall(o, "edge_management", "/edge-routers", limit, offset)
 		if err != nil {
 			return routerStructTotal, err
 		}


### PR DESCRIPTION
This new collector add Ziti Fabric Links metrics, and refactor the exporter for consuming an extra API