### PR TITLE
ziti: Add login metrics for tracking errors

### DIFF
--- a/collector/fabric_links_collector.go
+++ b/collector/fabric_links_collector.go
@@ -14,6 +14,9 @@
 package collector
 
 import (
+	"errors"
+	"fmt"
+
 	jsoniter "github.com/json-iterator/go"
 
 	"github.com/go-kit/log"
@@ -49,13 +52,20 @@ func (c *fabricLinksCollector) Update(ch chan<- prometheus.Metric) (err error) {
 	if c.options == nil {
 		c.options, err = edgeAPILogin(c.logger)
 		if err != nil {
+			errString := fmt.Sprintf("%s", errors.Unwrap(err))
+			zitiLoginErrors[errString]++
+
 			return err
 		}
+		zitiLoginSuccess++
 	} else if c.options.Token == "" {
 		c.options, err = edgeAPILogin(c.logger)
 		if err != nil {
+			errString := fmt.Sprintf("%s", errors.Unwrap(err))
+			zitiLoginErrors[errString]++
 			return err
 		}
+		zitiLoginSuccess++
 	}
 
 	fabricLinks, err := c.options.RunFabricLinks()

--- a/collector/identities_collector.go
+++ b/collector/identities_collector.go
@@ -89,13 +89,20 @@ func (c *identitiesCollector) Update(ch chan<- prometheus.Metric) (err error) {
 	if c.options == nil {
 		c.options, err = edgeAPILogin(c.logger)
 		if err != nil {
+			errString := fmt.Sprintf("%s", errors.Unwrap(err))
+			zitiLoginErrors[errString]++
+
 			return err
 		}
+		zitiLoginSuccess++
 	} else if c.options.Token == "" {
 		c.options, err = edgeAPILogin(c.logger)
 		if err != nil {
+			errString := fmt.Sprintf("%s", errors.Unwrap(err))
+			zitiLoginErrors[errString]++
 			return err
 		}
+		zitiLoginSuccess++
 	}
 
 	identities, err := c.options.RunIdentities()

--- a/collector/routers_collector.go
+++ b/collector/routers_collector.go
@@ -14,6 +14,8 @@
 package collector
 
 import (
+	"errors"
+	"fmt"
 	"math"
 	"strings"
 
@@ -50,13 +52,20 @@ func (c *routersCollector) Update(ch chan<- prometheus.Metric) (err error) {
 	if c.options == nil {
 		c.options, err = edgeAPILogin(c.logger)
 		if err != nil {
+			errString := fmt.Sprintf("%s", errors.Unwrap(err))
+			zitiLoginErrors[errString]++
+
 			return err
 		}
+		zitiLoginSuccess++
 	} else if c.options.Token == "" {
 		c.options, err = edgeAPILogin(c.logger)
 		if err != nil {
+			errString := fmt.Sprintf("%s", errors.Unwrap(err))
+			zitiLoginErrors[errString]++
 			return err
 		}
+		zitiLoginSuccess++
 	}
 
 	routers, err := c.options.RunRouters()


### PR DESCRIPTION
I found a case where there was a controller issue, and the exporter didn't recover itself. This counters should bring some more information about what exactly is going on in such cases. 