### PR TITLE
Force a new login when status code is 401

### DIFF
--- a/collector/collector_helper.go
+++ b/collector/collector_helper.go
@@ -64,6 +64,11 @@ func controllerAPICall(o *LoginOptions, api, endpoint string, limit, offset int)
 	}
 
 	if resp.StatusCode() != http.StatusOK {
+		if resp.StatusCode() == http.StatusUnauthorized {
+			// reset login token to force a new login
+			o.Token = ""
+		}
+
 		return nil, fmt.Errorf("unable to authenticate to %v. Status code: %v, Server returned: %v", hostReady, resp.Status(), util.PrettyPrintResponse(resp))
 	}
 


### PR DESCRIPTION
It seems that queries return error == nil on UNAUTHORIZED, and return only StatusCode 401. Force a new login in this case as well.

See,
```
"code": "UNAUTHORIZED",
"message": "The request could not be completed. The session is not authorized or the credentials are invalid"
```