### PR TITLE
ziti: Fix valid identities

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -17,11 +17,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: 1.21.x
       - name: Lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.54.2
+          version: v1.55.2
           args: --timeout=5m

--- a/collector/identities_config.go
+++ b/collector/identities_config.go
@@ -22,7 +22,7 @@ import (
 )
 
 var (
-	validIdentityTypes = []string{"user", "device", "service"}
+	validIdentityTypes = []string{"default", "router"}
 	zitiMgtAPI         = kingpin.Flag(
 		"ziti.mgt.api", "Ziti Management API.",
 	).Envar("ZITI_MGMT_API").Default("https://localhost:1281").String()


### PR DESCRIPTION
Since ziti-controller `>= 0.30.2` Identity Types are consolidated to *Default* and *Router*.