### PR TITLE
Update go minimum version to 1.22

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -23,5 +23,5 @@ jobs:
       - name: Lint
         uses: golangci/golangci-lint-action@v4
         with:
-          version: v1.56.2
+          version: v1.57.2
           args: --timeout=5m

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,8 @@
 module github.com/enthus-it/openziti_exporter
 
-go 1.21
-toolchain go1.22.1
+go 1.22
+
+toolchain go1.22.2
 
 require (
 	github.com/alecthomas/kingpin/v2 v2.4.0


### PR DESCRIPTION
Trivial PR for updating golang minimum version
