### PR TITLE
circleci: Use executors and more container labels

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,19 +7,20 @@ executors:
   golang:
     docker:
     - image: cimg/go:1.22.2
+  python:
+    docker:
+    - image: cimg/python:3.12
 
 jobs:
   codespell:
-    docker:
-    - image: cimg/python:3.12
+    executor: python
     steps:
     - checkout
     - run: pip3 install codespell
     - run: codespell --skip=".git,go.sum"
 
   build:
-    docker:
-    - image: cimg/go:1.21
+    executor: golang
     environment:
     - GHCR_IMAGE_NAME: "ghcr.io/enthus-it/openziti_exporter"
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ ARG OS="linux"
 FROM quay.io/prometheus/busybox-${OS}-${ARCH}:latest
 LABEL maintainer="Mario Trangoni <mjtrangoni@gmail.com>"
 LABEL org.opencontainers.image.source="https://github.com/enthus-it/openziti_exporter"
+LABEL org.opencontainers.image.description="Prometheus exporter for collecting OpenZiti Management Edge API information"
+LABEL org.opencontainers.image.licenses=Apache-2.0
 
 ARG ARCH="amd64"
 ARG OS="linux"


### PR DESCRIPTION
Trivial PR for removing executor redundancy, adding more docker image labels